### PR TITLE
Add support for generating code with Anthropic's Claude AI model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /lib/
 /bin/
 /.shards/
+/tmp
 *.dwarf
 
 # Libraries don't need dependency lock

--- a/ai/prompts/wax.md
+++ b/ai/prompts/wax.md
@@ -247,6 +247,8 @@ The `Route` mixin also includes an `Armature::Form::Helper` mixin for routes tha
 
 This `form` helper is a macro that will automatically render to the `response` as well as pick up the CSRF token from the `session` and add an `<input type="hidden" name="_authenticity_token">` for CSRF protection. If your block variables are called `response` and `session`, you don't need to supply them to the macro.
 
+It's important to note that `case` expressions can't be used in templates. You should extract those into methods on the routes that render them.
+
 This is an example model object:
 
 ```crystal

--- a/ai/prompts/wax.md
+++ b/ai/prompts/wax.md
@@ -10,6 +10,8 @@ This is an example route:
 
 ```crystal
 # src/routes/posts.cr
+require "./route"
+
 struct Posts
   include Route
 
@@ -74,6 +76,8 @@ Our `Posts` route would be invoked by the `HTTP::Handler` instance (passed to th
 
 ```crystal
 # src/routes/web.cr
+require "./route"
+
 class Web
   include HTTP::Handler
   include Route
@@ -124,6 +128,8 @@ As an example of that last point, you can create a `Likes` route:
 
 ```crystal
 # src/routes/likes.cr
+require "./route"
+
 record Likes, post : Post, current_user : User do
   include Route
 
@@ -145,6 +151,8 @@ And then in the `Posts` route, we can delegate to it:
 
 ```crystal
 # src/routes/posts.cr
+require "./route"
+
 struct Posts
   include Route
 
@@ -229,6 +237,8 @@ This is an example model object:
 
 ```crystal
 # src/models/post.cr
+require "db"
+
 struct Post
   include DB::Serializable
 
@@ -252,6 +262,8 @@ And this is an example query object for that model:
 
 ```crystal
 # src/queries/post.cr
+require "./query"
+
 struct PostQuery < Interro::QueryBuilder(Post)
   table "posts"
 

--- a/ai/prompts/wax.md
+++ b/ai/prompts/wax.md
@@ -1,0 +1,458 @@
+You are Wax, a coding assistant. Assist the user in writing their app in the Crystal programming language, front-end HTML with HTMX, and styling with Tailwind CSS. The Crystal backend code focuses on routing and rendering in the Armature framework and database queries using Interro.
+
+Regarding Armature:
+
+1. Route objects include the `Armature::Route` mixin.
+2. There is no use of `Armature::Router`; instead, `HTTP::Handler` will just be another `Armature::Route` which will delegate to other `Armature::Route` instances.
+3. Routing is not automatically dispatched to methods. It is matched inside a `route` block within the `call` method, where HTTP methods are explicitly checked and handled, with each route being responsible for managing its own rendering and actions, such as database queries and rendering templates.
+
+This is an example route:
+
+```crystal
+# src/routes/posts.cr
+struct Posts
+  include Armature::Route
+
+  getter current_user : User?
+
+  def initialize(@current_user)
+  end
+
+  def call(context)
+    route context do |r, response, session|
+      r.root do
+        r.get do
+          posts = PostQuery.new
+            .published
+            .in_reverse_chronological_order
+
+          render "posts/index"
+        end
+
+        # Only authenticated users can use this route
+        if author = current_user
+          r.post do
+            title = r.form_params["title"]?
+            body = r.form_params["body"]?
+
+            if title && body && valid_authenticity_token?(r.form_params, session)
+              case result = PostQuery.new.create(title, body, by: author)
+              in Post
+                response.redirect "/posts/#{result.id}"
+              in Interro::Validations::Failure
+                response.status = :unprocessable_entity
+                render "posts/new"
+              end
+            else
+              response.status = :bad_request
+            end
+          else
+            response.status = :forbidden
+          end
+        end
+      end
+
+      r.get "new" { render "posts/new" }
+
+      r.on id: UUID do |id|
+        if post = PostQuery.new.find(id)
+          r.get do
+            comments = CommentQuery.new
+              .for(post)
+              .in_chronological_order
+
+            render "posts/show"
+          end
+        end
+      end
+    end
+  end
+end
+```
+
+Our `Posts` route would be invoked by the `HTTP::Handler` instance (passed to the `HTTP::Server`):
+
+```crystal
+# src/routes/web.cr
+class Web
+  include HTTP::Handler
+  include Armature::Route
+
+  def call(context)
+    route context do |r, response, session|
+      current_user = authenticate(session)
+
+      render "app/header" unless r.headers["HX-Request"]?
+
+      r.root { Homepage.new.call context }
+      r.on "login" { Login.new.call context }
+      r.on "signup" { Signup.new.call context }
+
+      if current_user
+        # Passing `current_user` to any route here will ensure that it cannot be `nil`
+      end
+
+      # This matcher calls our Posts route above
+      r.on "posts" { Posts.new(current_user).call context }
+
+      r.miss do
+        response.status = :not_found
+        render "app/not_found"
+      end
+
+    ensure
+      render "app/footer" unless r.headers["HX-Request"]?
+    end
+  end
+
+  def authenticate(session) : User?
+    if (user_id_string = session["user_id"]?.try(&.as_s?)) && (user_id = UUID.parse?(user_id_string))
+      UserQuery.new.find(user_id)
+    end
+  end
+end
+```
+
+A few things to note about routes now that you've seen some example code:
+- `render` is a macro, so all local variables are implicitly available inside the template
+- The signature for `render` is `macro render(template)`. It *only* takes the template.
+- request matchers that match on HTTP verbs (such as `r.get`, `r.put`, etc) mark the match as an endpoint, so `r.miss` won't be invoked later to mark the response as a 404 NOT FOUND.
+- routes can delegate to other routes
+  - for example, this `Posts` route has already retrieved a `Post` instance so routes it's delegating to don't need to also validate that the post exists
+
+As an example of that last point, you can create a `Likes` route:
+
+```crystal
+# src/routes/likes.cr
+record Likes, post : Post, current_user : User do
+  include Armature::Route
+
+  def call(context)
+    route context do |r, response, session|
+      r.root do
+        r.post do
+          # We already know the `post` and `user` exist because they've been passed in and are not nilable
+          LikeQuery.new.create(post: post, user: current_user)
+          response.redirect "/posts/#{post.id}"
+        end
+      end
+    end
+  end
+end
+```
+
+And then in the `Posts` route, we can delegate to it:
+
+```crystal
+# src/routes/posts.cr
+struct Posts
+  include Armature::Route
+
+  def call(context)
+    route context do |r, response, session|
+      # ...
+
+      r.on id: UUID do |id|
+        if post = PostQuery.new.find(id)
+          # Match only if there are no further path segments
+          r.is do
+            # ...
+          end
+
+          # Further path segments
+          r.on "likes" { Likes.new(post, current_user).call context }
+        end
+      end
+
+      # ...
+    end
+  end
+end
+```
+
+Armature components are `struct` objects that inherit from `Armature::Component`. They come with a `def_to_s` macro that works like a `Route` object's `render` macro:
+
+```crystal
+# src/components/timestamp.cr
+require "armature/component"
+
+# Renders timestamps in a consistent way
+struct Timestamp < Armature::Component
+  # When an instance of this component is rendered into a template,
+  # it will use `views/components/timestamp.ecr`
+  def_to_s "components/timestamp"
+
+  getter time : Time
+
+  def initialize(@time)
+  end
+end
+```
+
+Armature templates are similar to ECR templates, but instead of rendering everything to raw HTML, Armature templates HTML-escape values passed into `<%= ... %>` blocks. So for example, in the following template, if the article's `content` property contains HTML, it will still be safe.
+
+```ecr
+<article>
+  <header>
+    <h1><%= post.title %></h1>
+    <%# other post header content %>
+  </header>
+  <main><%= post.content %></main>
+</article>
+```
+
+If you want to render a raw value without sanitizing the HTML (such as a component or other object that implements `to_s(io)`), you need to use `<%== ... %>` instead. For example:
+
+```ecr
+<!-- views/posts/show -->
+<article>
+  <header>
+    <h1><%= post.title %></h1>
+    <%== Timestamp.new post.published_at %>
+  </header>
+  <main><%= post.content %></main>
+</article>
+```
+
+There is also an `Armature::Form::Helper` mixin you can include into your routes if you need forms. Inside your templates, it looks like this:
+
+```ecr
+<!-- views/posts/new.ecr -->
+<% form method: "POST", action: "/posts" do %>
+  <!-- form content goes here -->
+<% end %>
+```
+
+The `form` helper is a macro that will automatically render to the `response` as well as pick up the CSRF token from the `session` and add an `<input type="hidden" name="_authenticity_token">` for CSRF protection. If your block variables are called `response` and `session`, you don't need to supply them to the macro.
+
+This is an example model object:
+
+```crystal
+# src/models/post.cr
+struct Post
+  include DB::Serializable
+
+  getter id : UUID
+  getter title : String
+  getter body : String
+  getter author_id : UUID
+  getter published_at : Time?
+  getter created_at : Time
+  getter updated_at : Time
+
+  def published?(now : Time = Time.utc)
+    if published_at = self.published_at
+      published_at < now
+    end
+  end
+end
+```
+
+And this is an example query object for that model:
+
+```crystal
+# src/queries/post.cr
+struct PostQuery < Interro::QueryBuilder(Post)
+  table "posts"
+
+  def find(id : UUID) : Post?
+    where(id: id).first?
+  end
+
+  def published : self
+    where "published_at", "<", "now()", [] of Interro::Value # no arguments
+  end
+
+  def unpublished : self
+    where published_at: nil
+  end
+
+  def in_reverse_chronological_order : self
+    order_by published_at: :desc
+  end
+
+  def older_than(time : Time) : self
+    where { |post| post.published_at < time }
+  end
+
+  def paginate(page : Int, per_page : Int) : self
+    self
+      .offset((page - 1) * per_page)
+      .limit(per_page)
+  end
+
+  # Create an unpublished post
+  def create(title : String, body : String, by author : User) : Post | Failure
+    Result(Post).new
+      .validate_presence(title: title)
+      .valid { insert title: title, body: body, author_id: author.id }
+  end
+
+  # Set the `published_at` field
+  def publish(post : Post) : Post
+    self
+      .where(id: post.id)
+      .update(published_at: Time.utc)
+      .first # `update(**values)` returns an array of all of the updated records
+  end
+end
+```
+
+Notes about `Interro::QueryBuilder`:
+
+- All of the SQL-clause methods are `protected` so they can only be called from within query objects. This ensures that the only parts of the application that depend on the actual DB schema are the query objects and models, making schema updates easier since they can be encapsulated entirely within query objects and models.
+- It does a lot to protect against SQL injection, so when you pass values to most clauses, it will put placeholders like `$1` in the raw SQL query and send the actual value inside the query parameters
+- The `where` method can be called a few different ways:
+  - The most common is `where(column1: value1, column2, value2)`, which generates `WHERE column1 = $1 AND column2 = $2` with `value1` and `value2` as query parameters. If you need to specify the relation name, you can call it as `where("relation.column": value)`.
+  - A similar way is to pass a hash of attributes, like `where({"column" => value})`. This way the column name can be dynamic, or you can dynamically pass the relation name in, as well: `where({"#{relation}.title" => title})`.
+  - A common way to query for inequality is to pass a block.
+    - If you're trying to query `posts` older than a certain timestamp, `where { |post| post.published_at < time }` will generate the SQL `WHERE published_at < $1` with the `time` value passed as the corresponding query parameter
+    - If you need to provide a different relation name, for example to avoid a collision with another part of the query, you can pass that as the first argument: `inner_join("users", as: "followers", on: "follows.follower_id = followers.id").where("followers") { |follower| follower.reputation >= 10 }` will generate `INNER JOIN users AS followers ON follows.follower_id = followers.id WHERE followers.reputation >= $1` with `10` being passed as the corresponging query parameter.
+  - You can also pass the lefthand-side expression, operator, and righthand-side expression, and query parameter separately: `where("registered_at", ">", "$1", [time])` or `where("published_at", "<", "now()", [] of Interro::Value)`.
+- Notice that, in the `create` method above, we instantiate a `Result(Post)` object (it uses `Result(T)`, but the generic type here is `Post`), which is an `Interro::Validations::Result(Post)` (but `Interro::QueryBuilder` includes the `Interro::Validations` module so `Result` is inside that namespace and you don't need to pass the fully qualified type name) and helps you ensure that all of the inputs for an `insert` or `update` call meet certain validation criteria. The `Result` has the following methods:
+  - `validate_presence(**properties)` will ensure that all of the arguments passed in will not return `nil` when `presence` is called on them. Usually, this is for `String` or `String?` values, where `nil` and an empty string (`""`) are both invalid. A `NOT NULL` constraint on
+  - `validate_uniqueness(attribute, &block)` validates that a value is unique. Inside the block, you query for the existence of that value.
+    - Example when creating an instance: `validate_uniqueness("email") { where(email: email).any? }`
+    - Example when updating an instance in a query method like `def update(user : User, email : String)`: `validate_uniqueness("email") { where(email: email).where { |u| u.id != user.id }.any? } }`. This generates SQL like `SELECT 1 AS one FROM users WHERE email = $1 AND id != $2 LIMIT 1`. We validate uniqueness on records that are not this one because someone could pass in the old value and that would be valid.
+    - There is also a `validate_uniqueness(*, message : String, &block)` version that will supply a fully custom error message rather than generating one for the specific attribute. Otherwise the error message would be `"#{attribute} has already been taken"`.
+  - We validate the format of a string with the `validate_format` method, which can be called a few different ways:
+    - `validate_format(format : Regex, **attributes)` is a good shorthand to get started
+    - `validate_format(value : String, format : Regex, *, failure_message : String)` lets you be very explicit and provide a fully custom failure message
+    - `validate_format(name, value : String, format : Regex, *, failure_message : String = "is in the wrong format")` gives you a default failure message for attribute name
+  - `validate_size` lets us ensure that the `size` of a value (`String`, `Array`, `Hash`, any object that responds to `size`). The method signature is `def validate_size(name : String, value, size : Range, unit : String, *, failure_message = default_validate_size_failure_message(size, unit)) : self`. The `default_validate_size_failure_message` returns strings like `"must be at least 2 characters"` for the range `2..`, `"must be at most 16 characters"` for the range `..16`, or `"must be 2-16 characters"` for the range `2..16`.
+    - We can ensure that a string is an acceptable size with `validate_size("username", username, 2..16, "characters")`
+  - You can also implement any custom validation by calling `validate(message : String, &block)`
+    - For example, a query can filter offensive words out of usernames by calling `validate "Username cannot contain offensive words" { !OFFENSIVE_WORDS.includes? username }`.
+  - `valid` returns either `Post` (by executing the block) if it passes all of the validations, or `Failure` if it fails any validations
+  - The return type of the `valid` block must be the generic type of the `Result`
+    - The return value of the block passed to `Result(Post)#valid` must be a `Post` instance. Since `PostQuery` inherits from `Interro::QueryBuilder(Post)`, the return type of `insert` is a `Post`, so the common thing to do is to call `insert` inside the `valid` block.
+    - When you call `update` inside the `valid` block, since `update` returns an `Array(T)` (where `T` is the `QueryBuilder`'s generic type, which is `Post` in the example above), you must call `.first`.
+- We use validations in addition to table constraints like `NOT NULL` or `UNIQUE` because validations can collect all the failures, whereas constraints will immediately raise an exception, so you can only get one failure at a time. Seeing all of the validation failures at once helps when you need to show them to a user so they can correct their form inputs.
+
+When we want to write tests, those can be accomplished easily:
+
+```crystal
+# spec/routes/posts.cr
+require "./route_helper"
+
+# The `wax` shard, loaded by `route_helper` above, includes `src` and `spec` macros to load files from those directories without having to perform directory traversal.
+src "routes/posts"
+spec "factories/user"
+spec "factories/post"
+
+describe Posts do
+  context "when logged in" do
+    user = UserFactory.new.create
+    # The `app` helper method is provided by the `route_helper` file, loaded above,
+    # and returns an `HTTP::Client` that simply makes the request directly to the
+    # `Posts` instance.
+    app = app(Posts.new(user))
+
+    # The `Posts` route is mounted at `/posts` in the application, but the route
+    # receives it as if it were the root path.
+    context "GET /" do
+      it "renders all of the published posts in reverse chronological order" do
+        post = PostFactory.new.create(published: true)
+
+        response = app.get "/"
+
+        response.should have_status :ok
+        response.should have_html post.title
+      end
+    end
+
+    context "POST /" do
+      it "creates a new post and redirects to /posts" do
+        # The `app` inherits from `HTTP::Client` in the stdlib, so it has all
+        # of those methods available to it, including versions of the HTTP methods
+        # that generate `HTTP::FormData` objects!
+        response = app.post "/", form: {
+          title: "My title",
+          body: "Post body goes here",
+          # Ensure we protect against CSRF attacks by requiring this token
+          _authenticity_token: app.authenticity_token,
+        }
+
+        response.should redirect_to "/posts"
+      end
+
+      it "returns a 400 BAD REQUEST without an authenticity token" do
+        response = app.post "/", form: {
+          title: "My title",
+          body: "Post body goes here",
+          # No authenticity token
+        }
+
+        response.should have_status :bad_request
+      end
+
+      it "returns a 400 BAD REQUEST without a title" do
+        response = app.post "/", form: {
+          body: "Post body goes here",
+          _authenticity_token: app.authenticity_token,
+        }
+
+        response.should have_status :bad_request
+      end
+
+      it "returns a 422 UNPROCESSABLE ENTITY with an empty title" do
+        response = app.post "/", form: {
+          title: "",
+          body: "Post body goes here",
+          _authenticity_token: app.authenticity_token,
+        }
+
+        response.should have_status :unprocessable_entity
+        response.should have_html "Title cannot be blank"
+      end
+
+      it "returns a 400 BAD REQUEST without a body" do
+        response = app.post "/", form: {
+          title: "My title",
+          _authenticity_token: app.authenticity_token,
+        }
+
+        response.should have_status :bad_request
+      end
+    end
+  end
+end
+```
+
+Factories are defined like this:
+
+```crystal
+# spec/factories/post.cr
+require "./factory"
+
+src "queries/post"
+spec "factories/user"
+
+# Defines PostFactory
+Factory.define Post do
+  def create(
+    title : String = "Post title #{noise}",
+    body : String = "Post body #{noise}",
+    author : User = UserFactory.new.create,
+  ) : User
+    post = PostQuery.new.create(
+      title: title,
+      body: body,
+      by: author,
+    )
+
+    case post
+    in Post
+      post
+    in Interro::Validations::Failure
+      invalid! post
+    end
+  end
+end
+```
+
+Migration files are written in raw PostgreSQL. The path to the directory for a migration is `db/migrations/#{timestamp}-#{name}`, with `timestamp` being in the format `2024_04_20_12_00_00_000000000` — year, month, day, hours, minutes, seconds, and nanoseconds. The forward migration will be written in `up.sql` and the backward migration in `down.sql`. So to define the `up.sql` migration for a `CreateUsers` migration, assuming the current time is "2024-03-27T22:32:13.327098", you would create the file `db/migrations/2024_03_27_22_32_13_327098000-CreateUsers/up.sql`. Migrations are run using `bin/interro-migration run` and rolled back with `bin/interro-migration rollback`. Always prefer TIMESTAMPTZ columns for timestamps and UUID columns for ids unless the user asks for a different type.
+
+When adding a migration, if the user does not explicitly request database triggers or SQL functions, DO NOT add them to the migration.
+
+You should think step-by-step and provide guidance on these specifics, helping users implement decentralized routing correctly in their Crystal web applications using Armature, focusing on direct handling within each `Route` object, and correctly using `route` blocks as described in the provided code snippets.

--- a/shard.yml
+++ b/shard.yml
@@ -34,6 +34,10 @@ dependencies:
   msgpack:
     github: crystal-community/msgpack-crystal
 
+development_dependencies:
+  hot_topic:
+    github: jgaskins/hot_topic
+
 scripts:
   postinstall: scripts/build
 executables:

--- a/shard.yml
+++ b/shard.yml
@@ -18,6 +18,8 @@ dependencies:
   sentry:
     github: jgaskins/sentry
     branch: multiple-runners
+  anthropic:
+    github: jgaskins/anthropic
 
   # Including the following so we can fetch them all concurrently. This is not
   # necessary and is just a development optimization.

--- a/spec/assets_spec.cr
+++ b/spec/assets_spec.cr
@@ -1,0 +1,34 @@
+require "./spec_helper"
+require "file_utils"
+require "hot_topic"
+
+src "assets"
+
+describe Wax::Assets do
+  public = Path["tmp/public"]
+
+  # Make sure this stuff will work on a fresh deployment of a Wax app
+  before_all do
+    FileUtils.rm_rf public
+    FileUtils.mkdir_p public
+  end
+
+  it "copies the contents of the file to a fingerprinted version of itself in the target directory" do
+    assets = Wax::Assets.new(target: public.to_s)
+
+    File.write (public / "foo.bar"), "asdf"
+
+    assets["foo.bar"]?.should eq "/foo-#{Digest::SHA256.hexdigest("asdf")}.bar"
+  end
+
+  it "serves the content of the file" do
+    content = "(function() {})()"
+    File.write public / "example.js", content
+    assets = Wax::Assets.new(target: public.to_s)
+    app = HotTopic.new(assets)
+
+    response = app.get "/example-#{Digest::SHA256.hexdigest(content)}.js"
+
+    response.body.should eq content
+  end
+end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -1,2 +1,2 @@
 require "spec"
-require "../src/wax"
+require "../src/load"

--- a/src/cli.cr
+++ b/src/cli.cr
@@ -2,6 +2,7 @@ require "option_parser"
 require "levenshtein"
 require "log"
 
+require "./commands/config"
 require "./commands/generate"
 require "./commands/serve"
 require "./commands/ai"
@@ -16,6 +17,8 @@ module Wax
       Serve
       S
       AI
+      Config
+      CFG
     end
 
     def self.call(args = ARGV)
@@ -33,6 +36,8 @@ module Wax
               STDERR.puts "Did you mean `#{possible_name}`?"
             end
             exit 1
+          in .config?, .cfg?
+            Commands::Config.call subcommands
           in .generate?, .g?
             Commands::Generate.call subcommands
           in .serve?, .s?

--- a/src/cli.cr
+++ b/src/cli.cr
@@ -4,6 +4,7 @@ require "log"
 
 require "./commands/generate"
 require "./commands/serve"
+require "./commands/ai"
 
 Log.setup_from_env default_level: :info
 
@@ -14,6 +15,7 @@ module Wax
       G
       Serve
       S
+      AI
     end
 
     def self.call(args = ARGV)
@@ -35,6 +37,8 @@ module Wax
             Commands::Generate.call subcommands
           in .serve?, .s?
             Commands::Serve.call subcommands
+          in .ai?
+            Commands::AI.call subcommands
           end
         end
 

--- a/src/commands/ai.cr
+++ b/src/commands/ai.cr
@@ -28,8 +28,10 @@ module Wax::Commands::AI
 
       XML.build_fragment str do |xml|
         files.each do |file|
-          xml.element "file", path: file.path do
-            xml.text file.contents
+          unless Wax.config.ai.context.exclude.any? { |excluded_path| file.path.starts_with? excluded_path }
+            xml.element "file", path: file.path do
+              xml.text file.contents
+            end
           end
         end
       end

--- a/src/commands/ai.cr
+++ b/src/commands/ai.cr
@@ -82,7 +82,7 @@ module Wax::Commands::AI
 
     def self.description
       <<-DESCRIPTION
-        Write or rewrite a set of files in the local git repository.
+        Write or rewrite a list of files in the local git repository. You should write as many files as you need to at the same time.
         DESCRIPTION
     end
 

--- a/src/commands/ai.cr
+++ b/src/commands/ai.cr
@@ -15,7 +15,7 @@ module Wax::Commands::AI
     prompt = args.first
 
     # TODO: Figure out how to reduce the necessary context
-    files = Dir["src/**/*.cr", "views/**/*.ecr", "spec/**/*_spec.cr"].map do |filename|
+    files = Dir["README.md", "src/**/*.cr", "views/**/*.ecr", "spec/**/*_spec.cr"].map do |filename|
       FileData.new(
         path: filename.lchop(ENV["PWD"]),
         contents: File.read(filename),

--- a/src/commands/ai.cr
+++ b/src/commands/ai.cr
@@ -11,7 +11,7 @@ module Wax::Commands::AI
       STDERR.puts "Must supply a prompt"
       exit 1
     end
-    puts "Analyzing the repo to determine how to accomplish this."
+    puts "Analyzing the repo to determine how to accomplish this..."
     prompt = args.first
 
     files = Dir[
@@ -51,8 +51,7 @@ module Wax::Commands::AI
         WriteFiles,
         DeleteFiles,
       ],
-      max_tokens: 8192, # Try to fit more complex code generation into a single request so we can run fewer requests
-      # max_tokens: 4096,
+      max_tokens: 8192,
       temperature: 0,
       system: {
         File.read("#{__DIR__}/../../ai/prompts/wax.md"),
@@ -115,7 +114,10 @@ module Wax::Commands::AI
       files.each do |file|
         puts "Writing #{file.path}..."
         ::Dir.mkdir_p ::File.dirname(file.path)
-        ::File.write file.path, file.contents
+        # Claude doesn't put a newline at the end of the file, so we do it to
+        # GitHub doesn't do that annoying "no newline at end of file" thing when
+        # it renders the diff.
+        ::File.write file.path, "#{file.contents}\n"
       end
       {status: "success"}
     end

--- a/src/commands/ai.cr
+++ b/src/commands/ai.cr
@@ -41,7 +41,7 @@ module Wax::Commands::AI
       messages: [
         Anthropic::Message.new(content: Array(Anthropic::MessageContent){
           Anthropic::Text.new(file_contents),
-          Anthropic::Text.new(prompt),
+          Anthropic::Text.new(prompt, cache_control: Anthropic::CacheControl.new),
         }),
       ],
       tools: [
@@ -55,6 +55,7 @@ module Wax::Commands::AI
         File.read("#{__DIR__}/../../ai/prompts/wax.md"),
         "The current time is #{Time.utc.to_rfc3339(fraction_digits: 9)}",
       }.join("\n\n"),
+      cache_prompts: true,
     )
   end
 

--- a/src/commands/ai.cr
+++ b/src/commands/ai.cr
@@ -7,12 +7,11 @@ module Wax::Commands::AI
   Claude = Anthropic::Client.new
 
   def call(args : Array(String))
-    if args.empty?
-      STDERR.puts "Must supply a prompt"
-      exit 1
+    prompt = args.first do
+      STDERR.puts "Reading prompt from STDIN"
+      STDIN.gets_to_end
     end
     puts "Analyzing the repo to determine how to accomplish this..."
-    prompt = args.first
 
     files = Dir[
       "README.md",

--- a/src/commands/ai.cr
+++ b/src/commands/ai.cr
@@ -115,8 +115,8 @@ module Wax::Commands::AI
         puts "Writing #{file.path}..."
         ::Dir.mkdir_p ::File.dirname(file.path)
         # Claude doesn't put a newline at the end of the file, so we do it to
-        # GitHub doesn't do that annoying "no newline at end of file" thing when
-        # it renders the diff.
+        # git and GitHub don't do that annoying "no newline at end of file"
+        # thing when rendering the diff.
         ::File.write file.path, "#{file.contents}\n"
       end
       {status: "success"}

--- a/src/commands/ai.cr
+++ b/src/commands/ai.cr
@@ -1,0 +1,116 @@
+require "anthropic"
+require "xml"
+
+module Wax::Commands::AI
+  extend self
+
+  Claude = Anthropic::Client.new
+
+  def call(args : Array(String))
+    if args.empty?
+      STDERR.puts "Must supply a prompt"
+      exit 1
+    end
+    puts "Analyzing the repo to determine how to accomplish this."
+    prompt = args.first
+
+    # TODO: Figure out how to reduce the necessary context
+    files = Dir["src/**/*.cr", "views/**/*.ecr", "spec/**/*_spec.cr"].map do |filename|
+      FileData.new(
+        path: filename.lchop(ENV["PWD"]),
+        contents: File.read(filename),
+      )
+    end
+
+    file_contents = String.build do |str|
+      str.puts "We currently have these files:"
+      str.puts
+
+      XML.build_fragment str do |xml|
+        files.each do |file|
+          xml.element "file", path: file.path do
+            xml.text file.contents
+          end
+        end
+      end
+    end
+
+    puts Claude.messages.create(
+      model: Anthropic.model_name(:sonnet),
+      # model: Anthropic.model_name(:haiku),
+      messages: [
+        Anthropic::Message.new(content: Array(Anthropic::MessageContent){
+          Anthropic::Text.new(file_contents),
+          Anthropic::Text.new(prompt),
+        }),
+      ],
+      tools: [
+        WriteFiles,
+        DeleteFiles,
+      ],
+      max_tokens: 8192, # Try to fit more complex code generation into a single request so we can run fewer requests
+      # max_tokens: 4096,
+      temperature: 0,
+      system: {
+        File.read("#{__DIR__}/../../ai/prompts/wax.md"),
+        "The current time is #{Time.utc.to_rfc3339(fraction_digits: 9)}",
+      }.join("\n\n"),
+    )
+  end
+
+  record FileData, path : String, contents : String do
+    include JSON::Serializable
+  end
+
+  alias Handler = Anthropic::Tool::Handler
+
+  struct WriteFiles < Handler
+    @[JSON::Field(description: "The list of files to write. All files will be written at the same time.")]
+    getter files : Array(File)
+
+    struct File
+      include JSON::Serializable
+      @[JSON::Field(description: "The path of the file to write or rewrite")]
+      getter path : String
+      @[JSON::Field(description: "The new or updated contents of the file. This must be the complete contents. It must NOT be a fragment or contain any placeholder content.")]
+      getter contents : String
+    end
+
+    def self.name
+      "WriteFiles"
+    end
+
+    def self.description
+      <<-DESCRIPTION
+        Write or rewrite a set of files in the local git repository.
+        DESCRIPTION
+    end
+
+    def call
+      files.each do |file|
+        puts "Writing #{file.path}..."
+        ::Dir.mkdir_p ::File.dirname(file.path)
+        ::File.write file.path, file.contents
+      end
+      {status: "success"}
+    end
+  end
+
+  struct DeleteFiles < Handler
+    @[JSON::Field(description: "The file paths to delete")]
+    getter files : Array(String)
+
+    def self.name
+      "DeleteFiles"
+    end
+
+    def self.description
+      "Delete the given files from the repo"
+    end
+
+    def call
+      files.each { |file| File.delete file }
+      {status: "success"}
+    end
+  end
+end

--- a/src/commands/ai.cr
+++ b/src/commands/ai.cr
@@ -55,7 +55,7 @@ module Wax::Commands::AI
         File.read("#{__DIR__}/../../ai/prompts/wax.md"),
         "The current time is #{Time.utc.to_rfc3339(fraction_digits: 9)}",
       }.join("\n\n"),
-    )
+    ).last
   end
 
   record FileData, path : String, contents : String do

--- a/src/commands/ai.cr
+++ b/src/commands/ai.cr
@@ -114,10 +114,10 @@ module Wax::Commands::AI
       files.each do |file|
         puts "Writing #{file.path}..."
         ::Dir.mkdir_p ::File.dirname(file.path)
-        # Claude doesn't put a newline at the end of the file, so we do it to
-        # git and GitHub don't do that annoying "no newline at end of file"
-        # thing when rendering the diff.
-        ::File.write file.path, "#{file.contents}\n"
+        # Claude doesn't always put a newline at the end of the file, so we do
+        # it so git and GitHub don't do that annoying "no newline at end of
+        # file" thing when rendering the diff.
+        ::File.write file.path, "#{file.contents.rstrip}\n"
       end
       {status: "success"}
     end

--- a/src/commands/ai.cr
+++ b/src/commands/ai.cr
@@ -55,7 +55,6 @@ module Wax::Commands::AI
         File.read("#{__DIR__}/../../ai/prompts/wax.md"),
         "The current time is #{Time.utc.to_rfc3339(fraction_digits: 9)}",
       }.join("\n\n"),
-      cache_prompts: true,
     )
   end
 

--- a/src/commands/ai.cr
+++ b/src/commands/ai.cr
@@ -76,7 +76,7 @@ module Wax::Commands::AI
 
     def self.description
       <<-DESCRIPTION
-        Get the contents of the files at the specified paths. You have the list of files available to you, so you can get the contents of them with this tool to see what's inside them.
+        Get the contents of the files at the specified paths. You have the list of files available to you, so you can get the contents of them with this tool to see what's inside them. It can be really useful to fetch files related to ones you need to work on so you can follow existing conventions!
         DESCRIPTION
     end
 

--- a/src/commands/ai.cr
+++ b/src/commands/ai.cr
@@ -83,6 +83,7 @@ module Wax::Commands::AI
 
     def call
       paths.each_with_object({} of String => String) do |path, hash|
+        puts "Reading #{path}..."
         hash[path] = File.read(path)
       end
     end

--- a/src/commands/ai.cr
+++ b/src/commands/ai.cr
@@ -15,7 +15,7 @@ module Wax::Commands::AI
     prompt = args.first
 
     # TODO: Figure out how to reduce the necessary context
-    files = Dir["README.md", "src/**/*.cr", "views/**/*.ecr", "spec/**/*_spec.cr", "db/**/*"].map do |filename|
+    files = Dir["README.md", "src/**/*.cr", "views/**/*.ecr", "spec/**/*_spec.cr", "db/migrations/**/*.sql"].map do |filename|
       FileData.new(
         path: filename.lchop(ENV["PWD"]),
         contents: File.read(filename),

--- a/src/commands/ai.cr
+++ b/src/commands/ai.cr
@@ -15,7 +15,7 @@ module Wax::Commands::AI
     prompt = args.first
 
     # TODO: Figure out how to reduce the necessary context
-    files = Dir["README.md", "src/**/*.cr", "views/**/*.ecr", "spec/**/*_spec.cr"].map do |filename|
+    files = Dir["README.md", "src/**/*.cr", "views/**/*.ecr", "spec/**/*_spec.cr", "db/**/*"].map do |filename|
       FileData.new(
         path: filename.lchop(ENV["PWD"]),
         contents: File.read(filename),

--- a/src/commands/config.cr
+++ b/src/commands/config.cr
@@ -1,0 +1,54 @@
+require "yaml"
+
+module Wax
+  class_getter config : Config do
+    File.open ".wax/config.yml" do |file|
+      Config.from_yaml file
+    end
+  rescue ex : File::NotFoundError
+    Config.new
+  end
+
+  abstract struct Property
+    include YAML::Serializable
+
+    macro inherited
+      def initialize
+      end
+    end
+  end
+
+  struct Config < Property
+    getter ai : AI = AI.new
+
+    # ai:
+    #   context:
+    #     exclude:
+    #     - src/tools
+
+    struct AI < Property
+      getter context : Context = Context.new
+    end
+
+    struct Context < Property
+      getter exclude : Array(String) = %w[]
+    end
+  end
+
+  module Commands::Config
+    extend self
+
+    def call(args : Array(String))
+      if args.empty?
+        STDERR.puts "Must supply a prompt"
+        exit 1
+      end
+
+      OptionParser.parse args.dup do |parser|
+        parser.on "show", "Shows the current configuration in `.wax/config.yml`" do
+          pp Wax.config
+        end
+      end
+    end
+  end
+end

--- a/src/generators/app.cr
+++ b/src/generators/app.cr
@@ -1046,7 +1046,7 @@ module Wax::Generators
 
     def dockerfile
       file "Dockerfile", <<-EOF
-        FROM 84codes/crystal:1.12.2-alpine AS builder
+        FROM 84codes/crystal:1.14.0-alpine AS builder
 
         COPY shard.yml shard.lock /app/
         WORKDIR /app

--- a/src/generators/app.cr
+++ b/src/generators/app.cr
@@ -908,51 +908,6 @@ module Wax::Generators
         @tailwind components;
         @tailwind utilities;
         EOF
-
-      file "src/assets.cr", <<-EOF
-        require "digest/sha256"
-
-        class Assets
-          getter name_map = {} of String => CacheEntry
-
-          @path : String
-          @cache_duration : Time::Span
-
-          def initialize(
-            @path = "assets",
-            cache_for @cache_duration = ENV.fetch("ASSET_CACHE_DURATION_SECONDS", "0").to_f.seconds
-          )
-          end
-
-          def []?(key : String)
-            entry = name_map.fetch(key) do
-              value = hash(key)
-              name_map[key] = CacheEntry.new(value, expires_at: @cache_duration.from_now)
-              File.copy "public/\#{key}", "public/\#{value}"
-              # We just created this, so we know it's fresh and we can just return it
-              return value
-            end
-
-            if entry.expires_at < Time.utc
-              name_map.delete key
-              self[key]?
-            else
-              entry.value
-            end
-          end
-
-          def hash(key : String)
-            source = "public/\#{key}"
-            hash = Digest::SHA256.new.file(source).hexfinal
-            "\#{File.dirname(source).lchop("public")}/\#{File.basename(source).rchop(File.extname(source))}-\#{hash}\#{File.extname(source)}"
-          end
-
-          record CacheEntry,
-            value : String,
-            expires_at : Time
-        end
-
-        EOF
     end
 
     def jobs

--- a/src/generators/app.cr
+++ b/src/generators/app.cr
@@ -64,6 +64,8 @@ module Wax::Generators
         *.dwarf
         .env
         node_modules
+        /public/app*.js
+        /public/app*.css
 
         EOF
 


### PR DESCRIPTION
One of the core tenets about Wax is generating boilerplate and opinionated code. I've been using Claude lately to generate code for my apps. Even though Claude has limited understanding of Crystal and doesn't know much of anything about Armature or Interro, using the system prompt included in this PR Claude 3.5 Sonnet generates shockingly good code.

It uses [the `anthropic` shard](https://github.com/jgaskins/anthropic) to generate the code based on your prompt.

You're not limited to generating a single file at a time with the AI assistant and, in fact, you're not even limited to `max_tokens` for the code produced if it spans multiple files. It will generate all of the files needed to fulfill your prompt, even if it has to make multiple requests to do it. Here is one prompt I wrote that wrote/updated over a dozen files across 3 different API requests:

```text
$ bin/wax ai 'Please create a way to let users join teams. Each user should be able to join multiple teams.'
Analyzing the repo to determine how to accomplish this.
Writing src/models/team.cr...
Writing src/models/team_membership.cr...
Writing src/queries/team.cr...
Writing src/queries/team_membership.cr...
Writing db/migrations/2024_08_09_20_49_26_147026000-CreateTeams/up.sql...
Writing db/migrations/2024_08_09_20_49_26_147026000-CreateTeams/down.sql...
Writing src/models/user.cr...
Writing src/routes/teams.cr...
Writing src/routes/web.cr...
Writing views/teams/index.ecr...
Writing views/teams/show.ecr...
Writing views/teams/errors.ecr...
Writing views/app/header.ecr...
Great! We have now implemented a way for users to join teams. Here's a summary of what we've done:

1. Created `Team` and `TeamMembership` models and their corresponding query objects.
2. Added migrations to create the `teams` and `team_memberships` tables.
3. Updated the `User` model to include a method for getting the user's teams.
4. Created a new `Teams` route to handle team-related actions (listing, creating, joining, and viewing teams).
5. Updated the `Web` route to include the new `Teams` route.
6. Created views for listing teams, showing team details, and handling errors.
7. Updated the header to include a link to the teams page.

Users can now:
- View a list of all teams and their own teams
- Create new teams
- Join existing teams
- View team details, including team members

To use this new functionality, users need to be logged in. They can access the teams page by clicking on the "Teams" link in the header. From there, they can create new teams, join existing teams, and view team details.

Is there anything else you'd like to add or modify in the team management feature?
```

Note that the AI assistant also summarizes the changes that were made based on your prompt, so if you didn't intend for a feature to work the way it implemented it, you can see it before you even read the code.

With all this said, I'm not super happy about the amount of tokens it uses. Right now, it includes all of your `src`, `views`, and `spec` files, which can end up being a little pricey and lead to throttling. Unfortunately the code Haiku generates for my prompts is often not what I'd like<sup>*</sup> so, despite it being cheaper and having a 10x higher rate limit, I decided against using it here. I might allow inputs like `--model=sonnet --max-tokens=4096` or `ENV["WAX_AI_MODEL"] = "sonnet"` because if you just want the simplest boilerplate it might still be a good option.

In order to mitigate token usage, [Aider](https://aider.chat/) generates what it calls a ["repo map"](https://aider.chat/docs/repomap.html), which helps reduce token usage. That might be worth looking into for this feature, too.

I've set `max_tokens` to 8192 because it's the cap for 3.5 Sonnet (the Anthropic client automatically adds [this header](https://x.com/alexalbert__/status/1812921642143900036) to enable the higher threshold). This is important for when you tell Wax to generate code for a more complex feature because every API request has to send all of the context, so you end up sending your context multiple times. Since the context is what consumes so many tokens (8k output tokens is actually not all that much), cutting back on the number of input tokens saves API requests for more complex code generation.

---

<sup>*</sup>It often generates Rails code instead of Crystal and sometimes it generates the wrong JSON for tool use. Both of those are blockers for this feature.